### PR TITLE
Make code compatible with Erlang versions older than R16B

### DIFF
--- a/src/stun.erl
+++ b/src/stun.erl
@@ -601,7 +601,7 @@ clean_treap(Treap, CleanPriority) ->
 
 make_nonce(Addr, Nonces) ->
     Priority = now_priority(),
-    Nonce = erlang:integer_to_binary(random:uniform(1 bsl 32)),
+    Nonce = list_to_binary(integer_to_list(random:uniform(1 bsl 32))),
     NewNonces = clean_treap(Nonces, Priority + ?NONCE_LIFETIME),
     {Nonce, treap:insert(Nonce, Priority, Addr, NewNonces)}.
 


### PR DESCRIPTION
`integer_to_binary/1` isn't available in Erlang versions older than R16B.
