### PR TITLE
fix otp 19 warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ otp_release:
   - 17.1
   - 17.5
   - 18.1
+  - 19.1
 
 after_success:
   - coveralls --exclude lib --exclude tests --gcov-options '\-lp' --dump c.json

--- a/include/compatible.hrl
+++ b/include/compatible.hrl
@@ -1,0 +1,16 @@
+-ifdef(otp_after_18).
+-define(RANDOM, rand).
+-define(seed(), rand:seed(exs1024)).
+-else.
+-define(RANDOM, random).
+-define(seed(), begin
+    {A, B, C} = p1_time_compat:timestamp(),
+    random:seed(A, B, C)
+end).
+-endif.
+
+-ifdef(otp_after_19).
+-define(rand_bytes(N), crypto:rand_bytes(N)).
+-else.
+-define(rand_bytes(N), crypto:strong_rand_bytes(N)).
+-endif.

--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,11 @@
 %%%
 %%%----------------------------------------------------------------------
 
-{erl_opts, [debug_info, {i, "include"}]}.
+{erl_opts, [
+  {platform_define, "18", otp_after_18},
+  {platform_define, "19", otp_after_18, otp_after_19},
+  debug_info, {i, "include"}
+]}.
 
 {deps, [{fast_tls, ".*", {git, "https://github.com/processone/fast_tls", {tag, "1.0.7"}}},
 	{p1_utils, ".*", {git, "https://github.com/processone/p1_utils", {tag, "1.0.5"}}}]}.

--- a/src/stun_test.erl
+++ b/src/stun_test.erl
@@ -35,6 +35,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include("stun.hrl").
+-include("compatible.hrl").
 
 init_test() ->
     ?assertEqual(ok, application:start(fast_tls)),
@@ -165,7 +166,7 @@ allocate_udp_test() ->
     {ok, #stun{trid = TrID3,
 	       class = response}} = stun_codec:decode(PktIn3, datagram),
     %% Sending some data to the peer. Peer receives it.
-    Data1 = crypto:rand_bytes(20),
+    Data1 = ?rand_bytes(20),
     TrID4 = mk_trid(),
     Msg4 = #stun{method = ?STUN_METHOD_SEND,
 		 trid = TrID4,
@@ -201,7 +202,7 @@ allocate_udp_test() ->
 		  class = response}},
        stun_codec:decode(PktIn5, datagram)),
     %% Now we send data to this channel. The peer receives it.
-    Data3 = crypto:rand_bytes(20),
+    Data3 = ?rand_bytes(20),
     Msg6 = #turn{channel = ?CHANNEL, data = Data3},
     PktOut6 = stun_codec:encode(Msg6),
     ?assertEqual(ok, gen_udp:send(Socket, {127,0,0,1}, ?STUN_PORT, PktOut6)),
@@ -354,9 +355,8 @@ recv(TLSSocket, Buf, true) ->
     end.
 
 mk_trid() ->
-    {A, B, C} = p1_time_compat:timestamp(),
-    random:seed(A, B, C),
-    random:uniform(1 bsl 96).
+    ?seed(),
+    ?RANDOM:uniform(1 bsl 96).
 
 get_cert() ->
     <<"-----BEGIN CERTIFICATE-----

--- a/src/turn.erl
+++ b/src/turn.erl
@@ -37,6 +37,7 @@
 -export([wait_for_allocate/2, active/2]).
 
 -include("stun.hrl").
+-include("compatible.hrl").
 
 %%-define(debug, true).
 -ifdef(debug).
@@ -115,8 +116,7 @@ init([Opts]) ->
 	    ok
     end,
     TRef = erlang:start_timer(?DEFAULT_LIFETIME, self(), stop),
-    {A1, A2, A3} = p1_time_compat:timestamp(),
-    random:seed(A1, A2, A3),
+    ?seed(),
     case turn_sm:add_allocation(AddrPort, Username, Realm, MaxAllocs, self()) of
 	ok ->
 	    {ok, wait_for_allocate, State#state{life_timer = TRef}};
@@ -438,7 +438,7 @@ time_left(TRef) ->
 %% draft-ietf-tsvwg-port-randomization-04
 allocate_addr({Min, Max}) ->
     Count = Max - Min + 1,
-    Next = Min + random:uniform(Count) - 1,
+    Next = Min + ?RANDOM:uniform(Count) - 1,
     allocate_addr(Min, Max, Next, Count).
 
 allocate_addr(_Min, _Max, _Next, 0) ->


### PR DESCRIPTION
Fix `random` and `crypto` warning for OTP 19.