### PR TITLE
Add p1_utils to stun.app.src

### DIFF
--- a/src/stun.app.src
+++ b/src/stun.app.src
@@ -26,7 +26,7 @@
   {vsn,          "1.0.16"},
   {modules,      []},
   {registered,   []},
-  {applications, [kernel, stdlib]},
+  {applications, [kernel, stdlib, p1_utils]},
   {mod,          {stun_app,[]}},
 
   %% hex.pm packaging:


### PR DESCRIPTION
I was getting this error when running an app that depends on stun:

```
14:51:00.822 [error] Error in process <0.1088.0> on node 'instance@example.com' with exit value:
{undef,[{p1_time_compat,timestamp,[],[]},{stun,seed,0,[{file,"/root/server/_build/default/lib/stun/src/stun.erl"},{line,647}]},{stun,udp_init,2,[{file,"/root/server/_build/default/lib/stun/src/stun.erl"},{line,104}]},{stun_listener,start_listener,4,[{file,"/root/server/_build/default/lib/stun/src/stun_listener.erl"},{line,148}]}]}
14:51:00.822 [error] listener on 3478/udp failed: {undef,[{p1_time_compat,timestamp,[],[]},{stun,seed,0,[{file,"/root/server/_build/default/lib/stun/src/stun.erl"},{line,647}]},{stun,udp_init,2,[{file,"/root/server/_build/default/lib/stun/src/stun.erl"},{line,104}]},{stun_listener,start_listener,4,[{file,"/root/server/_build/default/lib/stun/src/stun_listener.erl"},{line,148}]}]} 
```

It went away by adding `p1_utils` to the application resource file.