### PR TITLE
 TURN: allow multiple channels per IP (one per Port)

### DIFF
--- a/src/turn.erl
+++ b/src/turn.erl
@@ -320,7 +320,7 @@ check_channels(Channels,AddrPort,State) ->
 				false -> false
 			end
 		end, Channels),
-	case Found of [First | _] -> First; _Other -> 0 end.
+	case Found of [First | _] -> First; _Other -> undefined end.
 
 find_channel(Addr, Port,State) ->
 	AddrPort = {Addr, Port},


### PR DESCRIPTION
Ignoring the port is only correct for the Permission since we can't be sure what the peers port will be. For the channelBind the port should not be ignored because there can be multiple peers behind the same NAT. If the port is ignored only the first gets a channel and the TURN will mix up packets from both.

I've seen several smaller implementations of TURN doing this wrong in both directions, but the bigger ones do it right. For reference: https://github.com/jitsi/ice4j/blob/38e7b9226d6e1e790fe3b4ccacfeca64e9c2ed71/src/main/java/org/ice4j/socket/RelayedCandidateDatagramSocket.java