### PR TITLE
Log informational message on successful authentication

### DIFF
--- a/src/stun.erl
+++ b/src/stun.erl
@@ -241,9 +241,10 @@ process(#state{auth = user} = State,
 		    Key = {User, Realm, Pass},
 		    case stun_codec:check_integrity(Msg, Key) of
 			true ->
-			    ?dbg("accepted long-term STUN authentication "
-                                 "for ~s@~s from ~s",
-                                 [User, Realm, addr_to_str(State#state.peer)]),
+			    error_logger:info_msg(
+			      "accepted long-term STUN authentication "
+			      "for ~s@~s from ~s",
+			      [User, Realm, addr_to_str(State#state.peer)]),
 			    process(NewState, Msg, Key);
 			false ->
 			    error_logger:info_msg(


### PR DESCRIPTION
Log an `[info]` level message (and not just a debug message) if long-term credentials were accepted; analogous to, for example, ejabberd logging successful c2s/s2s authentications at this level.