### PR TITLE
Use maps instead of dict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 script: rebar compile xref && rebar skip_deps=true eunit
 
 otp_release:
-  - 17.1
+  - 18.0
   - 18.3
   - 19.3
   - 20.3


### PR DESCRIPTION
This bumps the minimum required Erlang/OTP version to 18.0, as Erlang/OTP 17.x doesn't have the `maps:filter/2` function.