### PR TITLE
 Make parameterizable the rebar binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,20 @@
+REBAR ?= rebar
+
 all: deps/% src
 
 deps/%:
-	rebar get-deps
+	$(REBAR) get-deps
 
 src:
-	rebar compile
+	$(REBAR) compile
 
 clean:
-	rebar clean
+	$(REBAR) clean
 
 doc:
-	rebar skip_deps=true doc
+	$(REBAR) skip_deps=true doc
 
 test: all
-	rebar -v skip_deps=true eunit
+	$(REBAR) -v skip_deps=true eunit
 
 .PHONY: clean src all doc rebar


### PR DESCRIPTION
Define the REBAR variable by a conditional assignment doesn't change the behavior of this Makefile but allows a package manager to explicity set the full path of the rebar binary.